### PR TITLE
fix: respect empty output.publicPath

### DIFF
--- a/module.js
+++ b/module.js
@@ -20,19 +20,20 @@ class WebpackCdnPlugin {
 
   apply(compiler) {
     const { output } = compiler.options;
-    output.publicPath = output.publicPath || '/';
 
-    if (output.publicPath.slice(-1) !== slash) {
-      output.publicPath += slash;
+    let outputPublicPath = output.publicPath || empty;
+
+    if (outputPublicPath.length > 0 && outputPublicPath.slice(-1) !== slash) {
+      outputPublicPath += slash;
     }
 
-    this.prefix = this.prod ? empty : this.prefix || output.publicPath;
+    this.prefix = this.prod ? empty : this.prefix || outputPublicPath;
 
-    if (!this.prod && this.prefix.slice(-1) !== slash) {
+    if (!this.prod && this.prefix.length > 0 && this.prefix.slice(-1) !== slash) {
       this.prefix += slash;
     }
 
-    const getArgs = [this.url, this.prefix, this.prod, output.publicPath];
+    const getArgs = [this.url, this.prefix, this.prod, outputPublicPath];
 
     compiler.hooks.compilation.tap('WebpackCdnPlugin', (compilation) => {
       compilation.hooks.htmlWebpackPluginBeforeHtmlGeneration.tapAsync('WebpackCdnPlugin', (data, callback) => {

--- a/spec/webpack.spec.js
+++ b/spec/webpack.spec.js
@@ -235,16 +235,16 @@ describe('Webpack Integration', () => {
       });
 
       it('should output the right assets (css)', () => {
-        expect(cssAssets).toEqual(['/local.css', '/nyc/style.css', '/jasmine/style.css']);
+        expect(cssAssets).toEqual(['local.css', 'nyc/style.css', 'jasmine/style.css']);
       });
 
       it('should output the right assets (js)', () => {
         expect(jsAssets).toEqual([
-          '/local.js',
-          '/jasmine-spec-reporter/index.js',
-          '/nyc/index.js',
-          '/jasmine/lib/jasmine.js',
-          '/app.js',
+          'local.js',
+          'jasmine-spec-reporter/index.js',
+          'nyc/index.js',
+          'jasmine/lib/jasmine.js',
+          'assets/app.js',
         ]);
       });
     });
@@ -305,24 +305,24 @@ describe('Webpack Integration', () => {
         );
       });
       it('should output the right assets (css)', () => {
-        expect(cssAssets).toEqual(['/local.css', '/nyc/style.css', '/jasmine/style.css']);
-        expect(cssAssets2).toEqual(['/local.css', '/nyc/style.css', '/archy/style.css']);
+        expect(cssAssets).toEqual(['local.css', 'nyc/style.css', 'jasmine/style.css']);
+        expect(cssAssets2).toEqual(['local.css', 'nyc/style.css', 'archy/style.css']);
       });
 
       it('should output the right assets (js)', () => {
         expect(jsAssets).toEqual([
-          '/local.js',
-          '/jasmine-spec-reporter/index.js',
-          '/nyc/index.js',
-          '/jasmine/lib/jasmine.js',
-          '/app.js',
+          'local.js',
+          'jasmine-spec-reporter/index.js',
+          'nyc/index.js',
+          'jasmine/lib/jasmine.js',
+          'assets/app.js',
         ]);
         expect(jsAssets2).toEqual([
-          '/local.js',
-          '/jasmine-core/index.js',
-          '/nyc/index.js',
-          '/archy/index.js',
-          '/app.js',
+          'local.js',
+          'jasmine-core/index.js',
+          'nyc/index.js',
+          'archy/index.js',
+          'assets/app.js',
         ]);
       });
     });


### PR DESCRIPTION
This is the same as #22, just changed the the source fork.

---

When the application is not served from the root of the server (ie https//domain.com/application1/), the additional "/" breaks the path to every assets.

I modified the code to keep the same behavior but without touching output.publicPath.

I had to modify the tests but I honestly think they where wrong in the first place.

You tested that the assets started with a "/" even when the `outputPath` is empty, this should not be the case.
Also your test output is `dist/assets` with the index being `../index.html`, as a consequence the path to the entry point should be `assets/app.js` not `app.js`.

Please tell me if this suits you, perhaps I broke some cases, but for me it works well 

- empty publicPath
- dev server begin accessed via Apache reverse proxy on "https://local/application1/"
- prod server on "https://domain.com/application1/"