### PR TITLE
Fix/custom prod url

### DIFF
--- a/module.js
+++ b/module.js
@@ -104,12 +104,21 @@ class WebpackCdnPlugin {
   }
 
   async alterAssetTags(pluginArgs) {
+    const getProdUrlPrefixes = () => {
+      const urls = this.modules[Reflect.ownKeys(this.modules)[0]]
+        .filter(m => m.prodUrl).map(m => m.prodUrl);
+      urls.push(this.url);
+      return [...new Set(urls)].map(url => url.split('/:')[0]);
+    };
+
+    const prefixes = getProdUrlPrefixes();
+
     const filterTag = (tag) => {
-      const prefix = this.url.split('/:')[0];
       const url = (tag.tagName === 'script' && tag.attributes.src)
         || (tag.tagName === 'link' && tag.attributes.href);
-      return url && url.indexOf(prefix) === 0;
+      return url && prefixes.filter(prefix => url.indexOf(prefix) === 0).length !== 0;
     };
+
     const processTag = async (tag) => {
       if (this.crossOrigin) {
         tag.attributes.crossorigin = this.crossOrigin;

--- a/spec/webpack.spec.js
+++ b/spec/webpack.spec.js
@@ -309,6 +309,10 @@ describe('Webpack Integration', () => {
       });
 
       it('should output the right assets (js)', () => {
+        expect(jsSri).toEqual(['sha384-GVSvp94Rbje0r89j7JfSj0QfDdJ9BkFy7YUaUZUgKNc4R6ibqFHWgv+eD1oufzAu']);
+      });
+
+      it('should output the right assets (js)', () => {
         expect(jsAssets).toEqual([
           `https://cdn.jsdelivr.net/npm/jasmine@${versions.jasmine}/lib/jasmine.js`,
           '/assets/app.js',

--- a/spec/webpack.spec.js
+++ b/spec/webpack.spec.js
@@ -5,7 +5,7 @@ const WebpackCdnPlugin = require('../module');
 const createSri = require('sri-create');
 
 const cssMatcher = /<link href="(.+?)" rel="stylesheet"( crossorigin="anonymous")?( integrity="sha.+")?>/g;
-const jsMatcher = /<script type="text\/javascript" src="(.+?)"( crossorigin="anonymous")?( integrity="sha.+")?>/g;
+const jsMatcher = /<script type="text\/javascript" src="([^"]+?)"( crossorigin="anonymous")?( integrity="sha[^"]+")?>/g;
 
 let cssAssets;
 let jsAssets;

--- a/spec/webpack.spec.js
+++ b/spec/webpack.spec.js
@@ -119,11 +119,29 @@ function getConfig({
     },
     { name: 'jasmine', cdn: 'jasmine2', style: 'style.css' },
   ];
+  if (sri) {
+    if (sri === 'jasmine') {
+      if (moduleProdUrl) {
+        modules = [
+          { name: 'jasmine', path: 'lib/jasmine.js' }
+        ];
+      } else {
+        modules = [
+          { name: 'jasmine', path: 'lib/jasmine.js' },
+          { name: 'bootstrap-css-only', style: 'css/bootstrap-grid.css', cssOnly: true },
+        ];
+      }
+    } else {
+      modules = [
+        { name: 'jasmine', path: 'notfound.js' },
+      ];
+    }
+  }
   if (moduleProdUrl) {
-    modules[2].prodUrl = moduleProdUrl;
+    modules[modules.length-1].prodUrl = moduleProdUrl;
   }
   if (moduleDevUrl) {
-    modules[2].devUrl = moduleDevUrl;
+    modules[modules.length-1].devUrl = moduleDevUrl;
   }
   if (multiple) {
     modules = {
@@ -156,19 +174,6 @@ function getConfig({
         styles: ['style2.css'],
       },
     ];
-  }
-
-  if (sri) {
-    if (sri === 'jasmine') {
-      modules = [
-      { name: 'jasmine', path: 'lib/jasmine.js' },
-      { name: 'bootstrap-css-only', style: 'css/bootstrap-grid.css', cssOnly: true },
-      ];
-    } else {
-      modules = [
-      { name: 'jasmine', path: 'notfound.js' },
-      ];
-    }
   }
   const options = {
     modules,
@@ -285,6 +290,27 @@ describe('Webpack Integration', () => {
           }/index.js`,
           `//cdnjs.cloudflare.com/ajax/libs/nyc/${versions.nyc}/index.js`,
           `//cdn.jsdelivr.net/npm/jasmine2@${versions.jasmine}/lib/jasmine.js`,
+          '/assets/app.js',
+        ]);
+      });
+    });
+
+    describe('When module `prodUrl` and `sri` are set', () => {
+      beforeAll((done) => {
+        runWebpack(
+          done,
+          getConfig({
+            prod: true,
+            sri: 'jasmine',
+            prodUrl: 'https://cdnjs.cloudflare.com/ajax/libs/:name/:version/:path',
+            moduleProdUrl: 'https://cdn.jsdelivr.net/npm/:name@:version/:path',
+          }),
+        );
+      });
+
+      it('should output the right assets (js)', () => {
+        expect(jsAssets).toEqual([
+          `https://cdn.jsdelivr.net/npm/jasmine@${versions.jasmine}/lib/jasmine.js`,
           '/assets/app.js',
         ]);
       });


### PR DESCRIPTION
I've noticed the SRI and cross origin options are not applied to resources that override the `prodUrl` setting, because the `this.url` in this code is the global `prodUrl` setting value, and that doesn't match the resource `prodUrl` https://github.com/shirotech/webpack-cdn-plugin/blob/955e1536036e97dec747a26ab53f8b80a94f4054/module.js#L108-L111


