### PR TITLE
Revert "Fix/custom prod url"

### DIFF
--- a/module.js
+++ b/module.js
@@ -104,21 +104,12 @@ class WebpackCdnPlugin {
   }
 
   async alterAssetTags(pluginArgs) {
-    const getProdUrlPrefixes = () => {
-      const urls = this.modules[Reflect.ownKeys(this.modules)[0]]
-        .filter(m => m.prodUrl).map(m => m.prodUrl);
-      urls.push(this.url);
-      return [...new Set(urls)].map(url => url.split('/:')[0]);
-    };
-
-    const prefixes = getProdUrlPrefixes();
-
     const filterTag = (tag) => {
+      const prefix = this.url.split('/:')[0];
       const url = (tag.tagName === 'script' && tag.attributes.src)
         || (tag.tagName === 'link' && tag.attributes.href);
-      return url && prefixes.filter(prefix => url.indexOf(prefix) === 0).length !== 0;
+      return url && url.indexOf(prefix) === 0;
     };
-
     const processTag = async (tag) => {
       if (this.crossOrigin) {
         tag.attributes.crossorigin = this.crossOrigin;

--- a/spec/webpack.spec.js
+++ b/spec/webpack.spec.js
@@ -309,10 +309,6 @@ describe('Webpack Integration', () => {
       });
 
       it('should output the right assets (js)', () => {
-        expect(jsSri).toEqual(['sha384-GVSvp94Rbje0r89j7JfSj0QfDdJ9BkFy7YUaUZUgKNc4R6ibqFHWgv+eD1oufzAu']);
-      });
-
-      it('should output the right assets (js)', () => {
         expect(jsAssets).toEqual([
           `https://cdn.jsdelivr.net/npm/jasmine@${versions.jasmine}/lib/jasmine.js`,
           '/assets/app.js',

--- a/spec/webpack.spec.js
+++ b/spec/webpack.spec.js
@@ -5,7 +5,7 @@ const WebpackCdnPlugin = require('../module');
 const createSri = require('sri-create');
 
 const cssMatcher = /<link href="(.+?)" rel="stylesheet"( crossorigin="anonymous")?( integrity="sha.+")?>/g;
-const jsMatcher = /<script type="text\/javascript" src="([^"]+?)"( crossorigin="anonymous")?( integrity="sha[^"]+")?>/g;
+const jsMatcher = /<script type="text\/javascript" src="(.+?)"( crossorigin="anonymous")?( integrity="sha.+")?>/g;
 
 let cssAssets;
 let jsAssets;

--- a/spec/webpack.spec.js
+++ b/spec/webpack.spec.js
@@ -119,29 +119,11 @@ function getConfig({
     },
     { name: 'jasmine', cdn: 'jasmine2', style: 'style.css' },
   ];
-  if (sri) {
-    if (sri === 'jasmine') {
-      if (moduleProdUrl) {
-        modules = [
-          { name: 'jasmine', path: 'lib/jasmine.js' }
-        ];
-      } else {
-        modules = [
-          { name: 'jasmine', path: 'lib/jasmine.js' },
-          { name: 'bootstrap-css-only', style: 'css/bootstrap-grid.css', cssOnly: true },
-        ];
-      }
-    } else {
-      modules = [
-        { name: 'jasmine', path: 'notfound.js' },
-      ];
-    }
-  }
   if (moduleProdUrl) {
-    modules[modules.length-1].prodUrl = moduleProdUrl;
+    modules[2].prodUrl = moduleProdUrl;
   }
   if (moduleDevUrl) {
-    modules[modules.length-1].devUrl = moduleDevUrl;
+    modules[2].devUrl = moduleDevUrl;
   }
   if (multiple) {
     modules = {
@@ -174,6 +156,19 @@ function getConfig({
         styles: ['style2.css'],
       },
     ];
+  }
+
+  if (sri) {
+    if (sri === 'jasmine') {
+      modules = [
+      { name: 'jasmine', path: 'lib/jasmine.js' },
+      { name: 'bootstrap-css-only', style: 'css/bootstrap-grid.css', cssOnly: true },
+      ];
+    } else {
+      modules = [
+      { name: 'jasmine', path: 'notfound.js' },
+      ];
+    }
   }
   const options = {
     modules,
@@ -290,27 +285,6 @@ describe('Webpack Integration', () => {
           }/index.js`,
           `//cdnjs.cloudflare.com/ajax/libs/nyc/${versions.nyc}/index.js`,
           `//cdn.jsdelivr.net/npm/jasmine2@${versions.jasmine}/lib/jasmine.js`,
-          '/assets/app.js',
-        ]);
-      });
-    });
-
-    describe('When module `prodUrl` and `sri` are set', () => {
-      beforeAll((done) => {
-        runWebpack(
-          done,
-          getConfig({
-            prod: true,
-            sri: 'jasmine',
-            prodUrl: 'https://cdnjs.cloudflare.com/ajax/libs/:name/:version/:path',
-            moduleProdUrl: 'https://cdn.jsdelivr.net/npm/:name@:version/:path',
-          }),
-        );
-      });
-
-      it('should output the right assets (js)', () => {
-        expect(jsAssets).toEqual([
-          `https://cdn.jsdelivr.net/npm/jasmine@${versions.jasmine}/lib/jasmine.js`,
           '/assets/app.js',
         ]);
       });


### PR DESCRIPTION
Reverts shirotech/webpack-cdn-plugin#70

@leibowitz sorry I will need to revert.

createSri seems to be unused and

```
    let matches, sriMatches;
    while ((matches = cssMatcher.exec(html))) {
      cssAssets.push(matches[1]);
      cssCrossOrigin.push(/crossorigin="anonymous"/.test(matches[2]));
      if (sriMatches = /integrity="(sha[^"]+)"/.exec(matches[3])) {
        cssSri.push(sriMatches[1]);
      }
    }
```

If you can refactor this to not use let, and also assignment in if's should be avoided. Many thanks.

Please feel free to open new PR with changes/fixes.